### PR TITLE
feat(gameplay): enforce code-reading code order and animate task flow

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,12 +13,10 @@ import EngineComponent from './components/EngineComponent';
 import GameControls from './components/GameControls';
 import LevelComplete from './components/LevelComplete';
 import FeedbackOverlay from './components/FeedbackOverlay';
+import EventLoopWidget from './components/EventLoopWidget';
+import FlowAnimation from './components/FlowAnimation';
 import EngineScene from './scene/EngineScene';
 
-/**
- * App — Main application component
- * Assembles 3D scene (background) + 2D game UI (overlay)
- */
 export default function App() {
   return (
     <GameProvider>
@@ -34,32 +32,31 @@ function GameBoard() {
 
   const [activeBall, setActiveBall] = useState(null);
 
-  // DnD Sensors
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: { distance: 5 },
     })
   );
 
-  // Handle drag start
   const handleDragStart = useCallback((event) => {
+    if (phase === 'animating' || phase === 'complete' || phase === 'ready') return;
     const ball = event.active.data.current?.ball;
     if (ball) setActiveBall(ball);
-  }, []);
+  }, [phase]);
 
-  // Handle drag end — validate placement
   const handleDragEnd = useCallback((event) => {
     const { active, over } = event;
     setActiveBall(null);
+
+    if (phase === 'animating' || phase === 'complete' || phase === 'ready') return;
 
     if (over && active.data.current?.ball) {
       const ballId = active.data.current.ball.id;
       const componentId = over.id;
       actions.placeBall(ballId, componentId);
     }
-  }, [actions]);
+  }, [actions, phase]);
 
-  // Get remaining ball objects
   const ballObjects = remainingBalls
     .map(id => level.balls.find(b => b.id === id))
     .filter(Boolean);
@@ -77,12 +74,10 @@ function GameBoard() {
         overflow: 'hidden',
         background: 'linear-gradient(145deg, #0f0a2e 0%, #1a0e3e 40%, #12082e 100%)',
       }}>
-        {/* === 3D SCENE (BACKGROUND) === */}
         <Suspense fallback={null}>
           <EngineScene phase={phase} />
         </Suspense>
 
-        {/* === BACKGROUND DECORATION === */}
         <div style={{
           position: 'absolute',
           inset: 0,
@@ -90,7 +85,6 @@ function GameBoard() {
           overflow: 'hidden',
           zIndex: 1,
         }}>
-          {/* Gradient orbs for depth */}
           <div style={{
             position: 'absolute',
             top: '10%',
@@ -121,7 +115,6 @@ function GameBoard() {
           }} />
         </div>
 
-        {/* === 2D UI OVERLAY === */}
         <div style={{
           position: 'relative',
           zIndex: 10,
@@ -134,14 +127,12 @@ function GameBoard() {
           padding: 20,
         }}>
 
-          {/* --- TOP BAR: Logo + Controls + Hint --- */}
           <div style={{
             gridColumn: '1 / -1',
             display: 'flex',
             alignItems: 'flex-start',
             gap: 16,
           }}>
-            {/* Logo + Game Controls */}
             <div style={{ flex: 1 }}>
               <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
                 <motion.span
@@ -166,13 +157,11 @@ function GameBoard() {
               <GameControls />
             </div>
 
-            {/* Hint Bubble — top right */}
             <div style={{ flexShrink: 0 }}>
               <HintBubble />
             </div>
           </div>
 
-          {/* --- LEFT COLUMN: Code + Output --- */}
           <div style={{
             display: 'flex',
             flexDirection: 'column',
@@ -183,48 +172,30 @@ function GameBoard() {
             <OutputPanel />
           </div>
 
-          {/* --- CENTER: Engine Components (Drop Zones) --- */}
           <div style={{
             display: 'grid',
             gridTemplateColumns: '1fr 1fr',
             gridTemplateRows: '1fr 1fr',
             gap: 12,
             alignContent: 'center',
+            position: 'relative',
           }}>
             {ENGINE_COMPONENTS.map((comp) => (
               <EngineComponent key={comp.id} component={comp} />
             ))}
 
-            {/* Event Loop indicator in center of grid */}
             <div style={{
               position: 'absolute',
               left: '50%',
               top: '50%',
               transform: 'translate(-50%, -50%)',
-              pointerEvents: 'none',
               zIndex: 5,
+              pointerEvents: 'none',
             }}>
-              <motion.div
-                animate={{ rotate: 360 }}
-                transition={{ duration: phase === 'execute' ? 2 : 8, repeat: Infinity, ease: 'linear' }}
-                style={{
-                  width: 60,
-                  height: 60,
-                  borderRadius: '50%',
-                  border: `3px solid ${phase === 'execute' ? 'rgba(251, 191, 36, 0.6)' : 'rgba(251, 191, 36, 0.2)'}`,
-                  borderTopColor: phase === 'execute' ? '#fbbf24' : 'rgba(251, 191, 36, 0.4)',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  boxShadow: phase === 'execute' ? '0 0 20px rgba(251, 191, 36, 0.3)' : 'none',
-                }}
-              >
-                <span style={{ fontSize: 18 }}>🔁</span>
-              </motion.div>
+              <EventLoopWidget />
             </div>
           </div>
 
-          {/* --- RIGHT COLUMN: Instructions --- */}
           <div className="glass-card" style={{
             padding: 16,
             display: 'flex',
@@ -243,32 +214,31 @@ function GameBoard() {
               </div>
               <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', marginBottom: 8 }}>
                 <span style={{ fontSize: 14, flexShrink: 0 }}>2️⃣</span>
-                <span>Drag the correct task ball to its engine component</span>
+                <span>Drag each task ball to its engine component <strong>in code order</strong></span>
               </div>
               <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', marginBottom: 8 }}>
                 <span style={{ fontSize: 14, flexShrink: 0 }}>3️⃣</span>
-                <span>Click <strong>Execute</strong> to run the task</span>
+                <span>Once all placed, click <strong>Execute</strong></span>
               </div>
               <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', marginBottom: 8 }}>
                 <span style={{ fontSize: 14, flexShrink: 0 }}>4️⃣</span>
-                <span>Watch the output appear in the terminal</span>
+                <span>Watch the animated flow through the engine!</span>
               </div>
               <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start' }}>
                 <span style={{ fontSize: 14, flexShrink: 0 }}>5️⃣</span>
-                <span>Complete all steps to finish the level!</span>
+                <span>See how the Event Loop moves tasks to the Call Stack</span>
               </div>
             </div>
 
-            {/* Color Legend */}
             <div style={{ marginTop: 'auto', paddingTop: 12, borderTop: '1px solid rgba(167, 139, 250, 0.15)' }}>
               <span style={{ fontWeight: 700, fontSize: 11, color: 'var(--color-text-dim)', letterSpacing: 1, display: 'block', marginBottom: 8 }}>
                 TASK TYPES
               </span>
               <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
                 {[
-                  { color: '#4ade80', label: 'Sync → Call Stack', emoji: '🟢' },
-                  { color: '#c084fc', label: 'Promise → Microtask', emoji: '🟣' },
-                  { color: '#60a5fa', label: 'setTimeout → Macrotask', emoji: '🔵' },
+                  { color: '#4ade80', label: 'Sync \u2192 Call Stack', emoji: '🟢' },
+                  { color: '#c084fc', label: 'Promise \u2192 Microtask', emoji: '🟣' },
+                  { color: '#60a5fa', label: 'setTimeout \u2192 Macrotask', emoji: '🔵' },
                 ].map((item) => (
                   <div key={item.label} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 11 }}>
                     <span>{item.emoji}</span>
@@ -279,7 +249,6 @@ function GameBoard() {
             </div>
           </div>
 
-          {/* --- BOTTOM: Task Balls Tray --- */}
           <div style={{
             gridColumn: '1 / -1',
             display: 'flex',
@@ -314,7 +283,7 @@ function GameBoard() {
                       initial={{ scale: 0, opacity: 0 }}
                       animate={{
                         scale: 1,
-                        opacity: 1,
+                        opacity: phase === 'animating' || phase === 'ready' ? 0.4 : 1,
                         y: [0, -4, 0],
                       }}
                       exit={{ scale: 0, opacity: 0 }}
@@ -332,7 +301,9 @@ function GameBoard() {
                     animate={{ opacity: 1 }}
                     style={{ fontSize: 13, color: 'var(--color-text-dim)' }}
                   >
-                    {phase === 'complete' ? '🎉 All done!' : '⏳ Execute to continue...'}
+                    {phase === 'complete' ? '🎉 All done!' :
+                     phase === 'ready' ? '✅ Ready to execute!' :
+                     phase === 'animating' ? '⚡ Running...' : '⏳ Place all balls...'}
                   </motion.span>
                 )}
               </AnimatePresence>
@@ -340,11 +311,10 @@ function GameBoard() {
           </div>
         </div>
 
-        {/* === OVERLAYS === */}
         <FeedbackOverlay />
         <LevelComplete />
+        <FlowAnimation />
 
-        {/* Drag overlay for smooth drag visuals */}
         <DragOverlay dropAnimation={{
           duration: 200,
           easing: 'cubic-bezier(0.18, 0.67, 0.6, 1.22)',

--- a/src/components/EngineComponent.jsx
+++ b/src/components/EngineComponent.jsx
@@ -1,37 +1,49 @@
 import { useDroppable } from '@dnd-kit/core';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useGame } from '../game/useGameStore';
+import { useEffect, useRef } from 'react';
 import TaskBall from './TaskBall';
 
-/**
- * EngineComponent — drop zone for task balls (Call Stack, Web API, Queues)
- * Shows placed balls inside with visual feedback
- */
 export default function EngineComponent({ component }) {
   const { id, label, color, borderColor, bgColor } = component;
-  const { placedBalls, level } = useGame();
+  const { placedBalls, level, registerComponentRef, animatingBall, phase } = useGame();
+  const containerRef = useRef(null);
 
   const { isOver, setNodeRef } = useDroppable({ id });
 
-  // Get balls placed in this component
+  useEffect(() => {
+    if (containerRef.current) {
+      registerComponentRef(id, containerRef.current);
+    }
+  }, [id, registerComponentRef]);
+
+  const setRefs = (el) => {
+    containerRef.current = el;
+    setNodeRef(el);
+  };
+
   const ballIds = placedBalls[id] || [];
   const balls = ballIds.map(bid => level.balls.find(b => b.id === bid)).filter(Boolean);
 
+  const isReceiving = animatingBall && animatingBall.to === id && phase === 'animating';
+  const isSending = animatingBall && animatingBall.from === id && phase === 'animating';
+
   return (
     <motion.div
-      ref={setNodeRef}
-      className={`engine-box ${isOver ? 'is-over' : ''}`}
+      ref={setRefs}
+      className={`engine-box ${isOver ? 'is-over' : ''} ${isReceiving ? 'receiving' : ''}`}
       style={{
         background: bgColor,
         border: `2px solid ${borderColor}`,
         boxShadow: isOver
           ? `0 0 30px ${borderColor}, inset 0 0 20px ${bgColor}`
+          : isReceiving
+          ? `0 0 25px ${color}40, inset 0 0 15px ${bgColor}`
           : `0 0 12px ${borderColor.replace('0.4', '0.15')}`,
       }}
-      animate={isOver ? { scale: 1.04 } : { scale: 1 }}
+      animate={isOver ? { scale: 1.04 } : isReceiving ? { scale: 1.02 } : { scale: 1 }}
       transition={{ type: 'spring', stiffness: 400, damping: 20 }}
     >
-      {/* Label */}
       <div style={{
         display: 'flex',
         alignItems: 'center',
@@ -50,7 +62,6 @@ export default function EngineComponent({ component }) {
         </span>
       </div>
 
-      {/* Placed Balls */}
       <div style={{
         display: 'flex',
         gap: 6,
@@ -64,7 +75,10 @@ export default function EngineComponent({ component }) {
             <motion.div
               key={ball.id}
               initial={{ scale: 0, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
+              animate={{
+                scale: 1,
+                opacity: isSending && animatingBall.ballId === ball.id ? 0.4 : 1,
+              }}
               exit={{ scale: 0, opacity: 0 }}
               transition={{ type: 'spring', stiffness: 500, damping: 20 }}
             >
@@ -77,7 +91,6 @@ export default function EngineComponent({ component }) {
                   cursor: 'default',
                 }}
               >
-                {/* Shine */}
                 <div style={{
                   position: 'absolute',
                   top: 4,
@@ -97,7 +110,6 @@ export default function EngineComponent({ component }) {
           ))}
         </AnimatePresence>
 
-        {/* Empty state */}
         {balls.length === 0 && (
           <motion.span
             animate={{ opacity: [0.3, 0.6, 0.3] }}
@@ -109,10 +121,26 @@ export default function EngineComponent({ component }) {
               opacity: 0.4,
             }}
           >
-            {isOver ? '✨ Drop here!' : 'Drop tasks here'}
+            {isOver ? 'Drop here!' : 'Drop tasks here'}
           </motion.span>
         )}
       </div>
+
+      {isReceiving && (
+        <motion.div
+          className="component-arrival-flash"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: [0, 0.4, 0] }}
+          transition={{ duration: 0.8, repeat: Infinity }}
+          style={{
+            position: 'absolute',
+            inset: 0,
+            borderRadius: 20,
+            background: `radial-gradient(circle, ${color}20 0%, transparent 70%)`,
+            pointerEvents: 'none',
+          }}
+        />
+      )}
     </motion.div>
   );
 }

--- a/src/components/EventLoopWidget.jsx
+++ b/src/components/EventLoopWidget.jsx
@@ -1,0 +1,110 @@
+import { motion } from 'framer-motion';
+import { useGame } from '../game/useGameStore';
+
+export default function EventLoopWidget() {
+  const { eventLoopActive, phase } = useGame();
+
+  const isSpinning = eventLoopActive || phase === 'animating';
+  const spinSpeed = eventLoopActive ? 1.2 : (phase === 'animating' ? 3 : 8);
+
+  return (
+    <div className="event-loop-widget">
+      <svg
+        viewBox="0 0 140 140"
+        width="140"
+        height="140"
+        style={{ position: 'absolute', inset: 0 }}
+      >
+        <defs>
+          <linearGradient id="outerGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stopColor="#fbbf24" />
+            <stop offset="50%" stopColor="#f97316" />
+            <stop offset="100%" stopColor="#fbbf24" />
+          </linearGradient>
+          <linearGradient id="innerGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stopColor="#f472b6" />
+            <stop offset="50%" stopColor="#c084fc" />
+            <stop offset="100%" stopColor="#f472b6" />
+          </linearGradient>
+          <filter id="glowFilter">
+            <feGaussianBlur stdDeviation="3" result="coloredBlur" />
+            <feMerge>
+              <feMergeNode in="coloredBlur" />
+              <feMergeNode in="SourceGraphic" />
+            </feMerge>
+          </filter>
+        </defs>
+
+        <motion.g
+          animate={{ rotate: 360 }}
+          transition={{ duration: spinSpeed, repeat: Infinity, ease: 'linear' }}
+          style={{ originX: '50%', originY: '50%', transformOrigin: '70px 70px' }}
+        >
+          <circle
+            cx="70" cy="70" r="58"
+            fill="none"
+            stroke="url(#outerGrad)"
+            strokeWidth="5"
+            strokeLinecap="round"
+            strokeDasharray="80 30 50 30"
+            filter={isSpinning ? "url(#glowFilter)" : "none"}
+            opacity={isSpinning ? 1 : 0.6}
+          />
+          <polygon points="118,52 128,62 118,62" fill="#fbbf24" />
+          <polygon points="22,78 12,68 22,68" fill="#fbbf24" />
+        </motion.g>
+
+        <motion.g
+          animate={{ rotate: -360 }}
+          transition={{ duration: spinSpeed * 1.5, repeat: Infinity, ease: 'linear' }}
+          style={{ originX: '50%', originY: '50%', transformOrigin: '70px 70px' }}
+        >
+          <circle
+            cx="70" cy="70" r="44"
+            fill="none"
+            stroke="url(#innerGrad)"
+            strokeWidth="4"
+            strokeLinecap="round"
+            strokeDasharray="60 25 40 25"
+            opacity={isSpinning ? 0.9 : 0.4}
+          />
+          <polygon points="108,55 114,62 104,62" fill="#f472b6" />
+          <polygon points="32,78 26,71 36,71" fill="#f472b6" />
+        </motion.g>
+      </svg>
+
+      <motion.div
+        className="event-loop-center"
+        animate={{
+          boxShadow: isSpinning
+            ? [
+                '0 0 15px rgba(251, 191, 36, 0.3)',
+                '0 0 30px rgba(251, 191, 36, 0.6)',
+                '0 0 15px rgba(251, 191, 36, 0.3)',
+              ]
+            : '0 0 10px rgba(251, 191, 36, 0.15)',
+        }}
+        transition={{ duration: 1.5, repeat: Infinity }}
+      >
+        <span className="event-loop-label">EVENT</span>
+        <span className="event-loop-label">LOOP</span>
+        <motion.div
+          className="event-loop-icon"
+          animate={{ rotate: isSpinning ? 360 : 0 }}
+          transition={{ duration: isSpinning ? 1 : 0, repeat: isSpinning ? Infinity : 0, ease: 'linear' }}
+        >
+          &#x21BB;
+        </motion.div>
+      </motion.div>
+
+      {isSpinning && (
+        <motion.div
+          className="event-loop-pulse-ring"
+          initial={{ scale: 0.8, opacity: 0.6 }}
+          animate={{ scale: 1.4, opacity: 0 }}
+          transition={{ duration: 1.5, repeat: Infinity }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/FlowAnimation.jsx
+++ b/src/components/FlowAnimation.jsx
@@ -1,0 +1,186 @@
+import { motion, AnimatePresence } from 'framer-motion';
+import { useGame } from '../game/useGameStore';
+import { useEffect, useState, useCallback } from 'react';
+import { TYPE_COLORS } from '../game/levels';
+
+export default function FlowAnimation() {
+  const {
+    animatingBall, phase, level, getComponentRect, actions,
+    currentFlowIndex, currentAnimWaypoint,
+  } = useGame();
+
+  const [fromPos, setFromPos] = useState(null);
+  const [toPos, setToPos] = useState(null);
+  const [ballData, setBallData] = useState(null);
+
+  const calculatePositions = useCallback(() => {
+    if (!animatingBall) return;
+
+    const fromRect = getComponentRect(animatingBall.from);
+    const toRect = getComponentRect(animatingBall.to);
+
+    if (fromRect) {
+      setFromPos({
+        x: fromRect.left + fromRect.width / 2,
+        y: fromRect.top + fromRect.height / 2,
+      });
+    }
+    if (toRect) {
+      setToPos({
+        x: toRect.left + toRect.width / 2,
+        y: toRect.top + toRect.height / 2,
+      });
+    }
+
+    const ball = level.balls.find(b => b.id === animatingBall.ballId);
+    setBallData(ball);
+  }, [animatingBall, getComponentRect, level]);
+
+  useEffect(() => {
+    if (phase !== 'animating' || !animatingBall) {
+      setFromPos(null);
+      setToPos(null);
+      setBallData(null);
+      return;
+    }
+
+    const timer = setTimeout(() => calculatePositions(), 50);
+    return () => clearTimeout(timer);
+  }, [phase, animatingBall, calculatePositions]);
+
+  const handleAnimationComplete = useCallback(() => {
+    if (!animatingBall) return;
+
+    const currentStep = level.flow[currentFlowIndex];
+    if (!currentStep) return;
+
+    const path = currentStep.animationPath;
+    const nextWaypoint = currentAnimWaypoint + 1;
+
+    if (nextWaypoint < path.length) {
+      setTimeout(() => actions.advanceWaypoint(), 300);
+    } else {
+      setTimeout(() => actions.finishFlowStep(), 400);
+    }
+  }, [animatingBall, level, currentFlowIndex, currentAnimWaypoint, actions]);
+
+  if (phase !== 'animating' || !animatingBall || !fromPos || !toPos || !ballData) {
+    return null;
+  }
+
+  const colors = TYPE_COLORS[ballData.type];
+  const isSameSpot = animatingBall.from === animatingBall.to;
+
+  if (isSameSpot) {
+    setTimeout(() => handleAnimationComplete(), 600);
+    return (
+      <div className="flow-animation-overlay">
+        <motion.div
+          className="flow-ball"
+          initial={{ scale: 0.5, opacity: 0 }}
+          animate={{
+            scale: [0.5, 1.3, 1],
+            opacity: [0, 1, 1],
+          }}
+          transition={{ duration: 0.5 }}
+          style={{
+            left: fromPos.x - 25,
+            top: fromPos.y - 25,
+            background: `radial-gradient(circle at 35% 35%, ${colors.bg}, ${colors.dark})`,
+            boxShadow: `0 0 30px ${colors.glow}, 0 0 60px ${colors.glow}`,
+          }}
+        >
+          <span className="flow-ball-label">{ballData.label}</span>
+        </motion.div>
+      </div>
+    );
+  }
+
+  const midX = (fromPos.x + toPos.x) / 2;
+  const midY = Math.min(fromPos.y, toPos.y) - 60;
+
+  return (
+    <div className="flow-animation-overlay">
+      <svg className="flow-trail-svg" width="100%" height="100%">
+        <defs>
+          <linearGradient id="trailGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+            <stop offset="0%" stopColor={colors.bg} stopOpacity="0" />
+            <stop offset="50%" stopColor={colors.bg} stopOpacity="0.6" />
+            <stop offset="100%" stopColor={colors.bg} stopOpacity="0" />
+          </linearGradient>
+          <filter id="trailGlow">
+            <feGaussianBlur stdDeviation="4" result="blur" />
+            <feMerge>
+              <feMergeNode in="blur" />
+              <feMergeNode in="SourceGraphic" />
+            </feMerge>
+          </filter>
+        </defs>
+        <motion.path
+          d={`M ${fromPos.x} ${fromPos.y} Q ${midX} ${midY} ${toPos.x} ${toPos.y}`}
+          fill="none"
+          stroke="url(#trailGrad)"
+          strokeWidth="3"
+          strokeLinecap="round"
+          filter="url(#trailGlow)"
+          initial={{ pathLength: 0, opacity: 0 }}
+          animate={{ pathLength: 1, opacity: 1 }}
+          transition={{ duration: 0.6, ease: 'easeOut' }}
+        />
+      </svg>
+
+      <motion.div
+        className="flow-ball"
+        initial={{
+          left: fromPos.x - 25,
+          top: fromPos.y - 25,
+          scale: 1,
+          opacity: 1,
+        }}
+        animate={{
+          left: toPos.x - 25,
+          top: toPos.y - 25,
+          scale: [1, 1.2, 1],
+        }}
+        transition={{
+          duration: 0.8,
+          ease: [0.25, 0.46, 0.45, 0.94],
+          scale: { duration: 0.8, times: [0, 0.5, 1] },
+        }}
+        onAnimationComplete={handleAnimationComplete}
+        style={{
+          background: `radial-gradient(circle at 35% 35%, ${colors.bg}, ${colors.dark})`,
+          boxShadow: `0 0 25px ${colors.glow}, 0 0 50px ${colors.glow}`,
+        }}
+      >
+        <div className="flow-ball-shine" />
+        <span className="flow-ball-label">{ballData.label}</span>
+      </motion.div>
+
+      <AnimatePresence>
+        <motion.div
+          className="flow-waypoint-label"
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0 }}
+          style={{
+            left: toPos.x,
+            top: toPos.y + 35,
+          }}
+        >
+          {getComponentLabel(animatingBall.to)}
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  );
+}
+
+function getComponentLabel(id) {
+  const labels = {
+    callstack: 'Call Stack',
+    webapi: 'Web API',
+    microtask: 'Microtask Queue',
+    macrotask: 'Macrotask Queue',
+  };
+  return labels[id] || id;
+}

--- a/src/components/GameControls.jsx
+++ b/src/components/GameControls.jsx
@@ -1,21 +1,28 @@
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion } from 'framer-motion';
 import { useGame } from '../game/useGameStore';
 import { LEVELS } from '../game/levels';
 
-/**
- * GameControls — Execute button, level tabs, score display, reset button
- */
 export default function GameControls() {
-  const { level, phase, score, currentLevelIndex, actions } = useGame();
+  const { level, phase, score, currentLevelIndex, allPlaced, actions } = useGame();
 
-  const canExecute = phase === 'execute';
+  const canExecute = phase === 'ready' && allPlaced;
+  const isAnimating = phase === 'animating';
   const isComplete = phase === 'complete';
+
+  const handleExecute = () => {
+    if (canExecute) {
+      actions.startExecution();
+    }
+  };
+
+  let buttonLabel = 'Place a ball';
+  if (canExecute) buttonLabel = 'Execute';
+  else if (isAnimating) buttonLabel = 'Running...';
+  else if (isComplete) buttonLabel = 'Done!';
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-      {/* Level Tabs + Score */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
-        {/* Level Tabs */}
         {LEVELS.map((lvl, i) => (
           <motion.button
             key={lvl.id}
@@ -23,6 +30,7 @@ export default function GameControls() {
             onClick={() => actions.initLevel(i)}
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
+            disabled={isAnimating}
             style={{
               color: i === currentLevelIndex ? 'var(--color-text)' : 'var(--color-text-dim)',
               background: i === currentLevelIndex
@@ -34,7 +42,6 @@ export default function GameControls() {
           </motion.button>
         ))}
 
-        {/* Score */}
         <div style={{ marginLeft: 'auto' }}>
           <motion.span
             className="score-badge"
@@ -43,12 +50,11 @@ export default function GameControls() {
             animate={{ scale: 1 }}
             transition={{ type: 'spring', stiffness: 500 }}
           >
-            ⭐ {score}
+            {score}
           </motion.span>
         </div>
       </div>
 
-      {/* Level Title */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
         <motion.h2
           key={level.id}
@@ -67,21 +73,19 @@ export default function GameControls() {
         </motion.h2>
       </div>
 
-      {/* Description */}
       <p style={{ fontSize: 13, color: 'var(--color-text-dim)', margin: 0, lineHeight: 1.4 }}>
         {level.description}
       </p>
 
-      {/* Action Buttons */}
       <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
         <motion.button
           className="btn-execute"
-          onClick={actions.executeStep}
+          onClick={handleExecute}
           disabled={!canExecute}
           whileHover={canExecute ? { scale: 1.05 } : {}}
           whileTap={canExecute ? { scale: 0.95 } : {}}
         >
-          {canExecute ? '▶ Execute' : isComplete ? '✅ Done!' : '⏳ Place a ball'}
+          {canExecute ? '\u25B6 ' : ''}{buttonLabel}
         </motion.button>
 
         <motion.button
@@ -89,8 +93,9 @@ export default function GameControls() {
           onClick={actions.resetLevel}
           whileHover={{ scale: 1.05 }}
           whileTap={{ scale: 0.95 }}
+          disabled={isAnimating}
         >
-          🔄 Reset
+          Reset
         </motion.button>
       </div>
     </div>

--- a/src/game/levels.js
+++ b/src/game/levels.js
@@ -1,15 +1,9 @@
-/**
- * Level definitions for Async Rush
- * Each level has: code lines, task balls, expected execution flow, and hints
- */
-
 export const LEVELS = [
-  // ===== LEVEL 1: Synchronous Only =====
   {
     id: 1,
     title: "Hello, Sync World!",
     description: "Learn how synchronous code runs on the Call Stack",
-    hint: "Synchronous code runs line by line, top to bottom! 🚀",
+    hint: "Synchronous code runs line by line, top to bottom!",
     code: [
       { text: 'console.log("Hello");', type: 'sync', color: '#4ade80' },
       { text: 'console.log("World");', type: 'sync', color: '#4ade80' },
@@ -20,20 +14,34 @@ export const LEVELS = [
       { id: 'b2', label: '"World"',  type: 'sync', target: 'callstack' },
       { id: 'b3', label: '"!"',      type: 'sync', target: 'callstack' },
     ],
+    placementOrder: ['b1', 'b2', 'b3'],
     flow: [
-      // Each step: which ball, where it goes, what output it produces
-      { ballId: 'b1', component: 'callstack', output: 'Hello' },
-      { ballId: 'b2', component: 'callstack', output: 'World' },
-      { ballId: 'b3', component: 'callstack', output: '!' },
+      {
+        ballId: 'b1',
+        component: 'callstack',
+        output: 'Hello',
+        animationPath: ['callstack'],
+      },
+      {
+        ballId: 'b2',
+        component: 'callstack',
+        output: 'World',
+        animationPath: ['callstack'],
+      },
+      {
+        ballId: 'b3',
+        component: 'callstack',
+        output: '!',
+        animationPath: ['callstack'],
+      },
     ],
   },
 
-  // ===== LEVEL 2: Introducing Promises =====
   {
     id: 2,
     title: "Promise Me This",
     description: "Promises create microtasks that run after sync code",
-    hint: "Microtasks (Promises) run AFTER all synchronous code, but BEFORE macrotasks! 🔮",
+    hint: "Microtasks (Promises) run AFTER all synchronous code, but BEFORE macrotasks!",
     code: [
       { text: 'console.log("Start");',                         type: 'sync',    color: '#4ade80' },
       { text: 'Promise.resolve().then(() =>',                   type: 'promise', color: '#c084fc' },
@@ -46,19 +54,34 @@ export const LEVELS = [
       { id: 'b2', label: '"Promise"', type: 'promise',  target: 'microtask' },
       { id: 'b3', label: '"End"',     type: 'sync',    target: 'callstack' },
     ],
+    placementOrder: ['b1', 'b2', 'b3'],
     flow: [
-      { ballId: 'b1', component: 'callstack',  output: 'Start' },
-      { ballId: 'b3', component: 'callstack',  output: 'End' },
-      { ballId: 'b2', component: 'microtask',  output: 'Promise' },
+      {
+        ballId: 'b1',
+        component: 'callstack',
+        output: 'Start',
+        animationPath: ['callstack'],
+      },
+      {
+        ballId: 'b3',
+        component: 'callstack',
+        output: 'End',
+        animationPath: ['callstack'],
+      },
+      {
+        ballId: 'b2',
+        component: 'microtask',
+        output: 'Promise',
+        animationPath: ['callstack', 'webapi', 'microtask', 'callstack'],
+      },
     ],
   },
 
-  // ===== LEVEL 3: setTimeout =====
   {
     id: 3,
     title: "Timeout Trickery",
     description: "setTimeout creates macrotasks via the Web API",
-    hint: "setTimeout goes to Web API first, then to the Macrotask Queue! ⏰",
+    hint: "setTimeout goes to Web API first, then to the Macrotask Queue!",
     code: [
       { text: 'console.log("First");',                          type: 'sync',    color: '#4ade80' },
       { text: 'setTimeout(() => {',                              type: 'timeout', color: '#60a5fa' },
@@ -71,19 +94,34 @@ export const LEVELS = [
       { id: 'b2', label: '"Timeout"', type: 'timeout', target: 'macrotask' },
       { id: 'b3', label: '"Last"',    type: 'sync',    target: 'callstack' },
     ],
+    placementOrder: ['b1', 'b2', 'b3'],
     flow: [
-      { ballId: 'b1', component: 'callstack',  output: 'First' },
-      { ballId: 'b3', component: 'callstack',  output: 'Last' },
-      { ballId: 'b2', component: 'macrotask',  output: 'Timeout' },
+      {
+        ballId: 'b1',
+        component: 'callstack',
+        output: 'First',
+        animationPath: ['callstack'],
+      },
+      {
+        ballId: 'b3',
+        component: 'callstack',
+        output: 'Last',
+        animationPath: ['callstack'],
+      },
+      {
+        ballId: 'b2',
+        component: 'macrotask',
+        output: 'Timeout',
+        animationPath: ['callstack', 'webapi', 'macrotask', 'callstack'],
+      },
     ],
   },
 
-  // ===== LEVEL 4: The Full Mix =====
   {
     id: 4,
     title: "The Grand Finale",
     description: "Combine sync, Promises, and setTimeout!",
-    hint: "Order: Sync first → Microtasks (Promise) → Macrotasks (setTimeout) 🎯",
+    hint: "Order: Sync first, then Microtasks (Promise), then Macrotasks (setTimeout)",
     code: [
       { text: 'console.log("Start");',                          type: 'sync',    color: '#4ade80' },
       { text: 'setTimeout(() =>',                                type: 'timeout', color: '#60a5fa' },
@@ -98,26 +136,45 @@ export const LEVELS = [
       { id: 'b3', label: '"Promise"', type: 'promise',  target: 'microtask' },
       { id: 'b4', label: '"End"',     type: 'sync',    target: 'callstack' },
     ],
+    placementOrder: ['b1', 'b2', 'b3', 'b4'],
     flow: [
-      { ballId: 'b1', component: 'callstack',  output: 'Start' },
-      { ballId: 'b4', component: 'callstack',  output: 'End' },
-      { ballId: 'b3', component: 'microtask',  output: 'Promise' },
-      { ballId: 'b2', component: 'macrotask',  output: 'Timeout' },
+      {
+        ballId: 'b1',
+        component: 'callstack',
+        output: 'Start',
+        animationPath: ['callstack'],
+      },
+      {
+        ballId: 'b4',
+        component: 'callstack',
+        output: 'End',
+        animationPath: ['callstack'],
+      },
+      {
+        ballId: 'b3',
+        component: 'microtask',
+        output: 'Promise',
+        animationPath: ['callstack', 'webapi', 'microtask', 'callstack'],
+      },
+      {
+        ballId: 'b2',
+        component: 'macrotask',
+        output: 'Timeout',
+        animationPath: ['callstack', 'webapi', 'macrotask', 'callstack'],
+      },
     ],
   },
 ];
 
-/** Color map for ball types */
 export const TYPE_COLORS = {
   sync:    { bg: '#4ade80', glow: 'rgba(74, 222, 128, 0.5)',  dark: '#052e16' },
   promise: { bg: '#c084fc', glow: 'rgba(192, 132, 252, 0.5)', dark: '#3b0764' },
   timeout: { bg: '#60a5fa', glow: 'rgba(96, 165, 250, 0.5)',  dark: '#1e3a5f' },
 };
 
-/** Engine component definitions */
 export const ENGINE_COMPONENTS = [
-  { id: 'callstack', label: '📚 Call Stack',       color: '#4ade80', borderColor: 'rgba(74, 222, 128, 0.4)',  bgColor: 'rgba(74, 222, 128, 0.08)' },
-  { id: 'webapi',    label: '🌐 Web API',          color: '#fbbf24', borderColor: 'rgba(251, 191, 36, 0.4)',  bgColor: 'rgba(251, 191, 36, 0.08)' },
-  { id: 'microtask', label: '⚡ Microtask Queue',  color: '#c084fc', borderColor: 'rgba(192, 132, 252, 0.4)', bgColor: 'rgba(192, 132, 252, 0.08)' },
-  { id: 'macrotask', label: '⏰ Macrotask Queue',  color: '#60a5fa', borderColor: 'rgba(96, 165, 250, 0.4)',  bgColor: 'rgba(96, 165, 250, 0.08)' },
+  { id: 'callstack', label: 'Call Stack',       color: '#4ade80', borderColor: 'rgba(74, 222, 128, 0.4)',  bgColor: 'rgba(74, 222, 128, 0.08)' },
+  { id: 'webapi',    label: 'Web API',          color: '#fbbf24', borderColor: 'rgba(251, 191, 36, 0.4)',  bgColor: 'rgba(251, 191, 36, 0.08)' },
+  { id: 'microtask', label: 'Microtask Queue',  color: '#c084fc', borderColor: 'rgba(192, 132, 252, 0.4)', bgColor: 'rgba(192, 132, 252, 0.08)' },
+  { id: 'macrotask', label: 'Macrotask Queue',  color: '#60a5fa', borderColor: 'rgba(96, 165, 250, 0.4)',  bgColor: 'rgba(96, 165, 250, 0.08)' },
 ];

--- a/src/game/useGameStore.jsx
+++ b/src/game/useGameStore.jsx
@@ -1,24 +1,24 @@
-import { createContext, useContext, useReducer, useCallback } from 'react';
+import { createContext, useContext, useReducer, useCallback, useRef } from 'react';
 import { LEVELS } from './levels';
-
-/**
- * Game State Management (Context + useReducer)
- * Handles: level progression, ball placement, execution flow, scoring
- */
 
 const initialState = {
   currentLevelIndex: 0,
-  currentStepIndex: 0,
-  phase: 'drag',        // 'drag' | 'execute' | 'animating' | 'complete'
+  currentPlacementIndex: 0,
+  currentFlowIndex: 0,
+  currentAnimWaypoint: 0,
+  phase: 'drag',
   score: 0,
   totalMoves: 0,
   wrongMoves: 0,
-  outputs: [],           // strings that appear in terminal
-  placedBalls: {},        // { componentId: [ballId, ...] }
-  remainingBalls: [],     // balls still in the tray
-  executedBalls: [],      // balls that have been executed
-  feedback: null,         // { type: 'success'|'error', ballId, message } or null
+  outputs: [],
+  placedBalls: {},
+  remainingBalls: [],
+  executedBalls: [],
+  feedback: null,
   showLevelComplete: false,
+  animatingBall: null,
+  eventLoopActive: false,
+  allPlaced: false,
 };
 
 function getLevel(state) {
@@ -34,7 +34,9 @@ function gameReducer(state, action) {
       return {
         ...state,
         currentLevelIndex: action.levelIndex ?? state.currentLevelIndex,
-        currentStepIndex: 0,
+        currentPlacementIndex: 0,
+        currentFlowIndex: 0,
+        currentAnimWaypoint: 0,
         phase: 'drag',
         outputs: [],
         placedBalls: {},
@@ -44,66 +46,155 @@ function gameReducer(state, action) {
         showLevelComplete: false,
         wrongMoves: 0,
         totalMoves: 0,
+        animatingBall: null,
+        eventLoopActive: false,
+        allPlaced: false,
       };
     }
 
     case 'PLACE_BALL': {
       const { ballId, componentId } = action;
-      const expectedStep = level.flow[state.currentStepIndex];
+      const expectedBallId = level.placementOrder[state.currentPlacementIndex];
+      const expectedBall = level.balls.find(b => b.id === expectedBallId);
 
-      // Validate: is this the correct ball in the correct component?
-      if (expectedStep && expectedStep.ballId === ballId && expectedStep.component === componentId) {
-        // Correct placement!
+      if (!expectedBall) return state;
+
+      if (ballId === expectedBallId && componentId === expectedBall.target) {
         const newPlaced = { ...state.placedBalls };
         if (!newPlaced[componentId]) newPlaced[componentId] = [];
         newPlaced[componentId] = [...newPlaced[componentId], ballId];
 
+        const nextPlacementIndex = state.currentPlacementIndex + 1;
+        const allPlaced = nextPlacementIndex >= level.placementOrder.length;
+
         return {
           ...state,
+          currentPlacementIndex: nextPlacementIndex,
           placedBalls: newPlaced,
           remainingBalls: state.remainingBalls.filter(id => id !== ballId),
-          feedback: { type: 'success', ballId, message: 'Correct! 🎉' },
+          feedback: { type: 'success', ballId, message: 'Correct!' },
           totalMoves: state.totalMoves + 1,
-          phase: 'execute', // ready to execute this step
+          allPlaced,
+          phase: allPlaced ? 'ready' : 'drag',
         };
       } else {
-        // Wrong placement
+        let message = 'Try again!';
+        if (ballId !== expectedBallId) {
+          const expectedLabel = expectedBall.label;
+          message = `Place ${expectedLabel} first!`;
+        } else {
+          message = `Wrong component!`;
+        }
         return {
           ...state,
-          feedback: { type: 'error', ballId, message: 'Try again! 🤔' },
+          feedback: { type: 'error', ballId, message },
           wrongMoves: state.wrongMoves + 1,
           totalMoves: state.totalMoves + 1,
         };
       }
     }
 
-    case 'EXECUTE_STEP': {
-      const expectedStep = level.flow[state.currentStepIndex];
-      if (!expectedStep) return state;
+    case 'START_EXECUTION': {
+      if (!state.allPlaced) return state;
+      const firstStep = level.flow[0];
+      if (!firstStep) return state;
 
-      const nextStepIndex = state.currentStepIndex + 1;
-      const isLastStep = nextStepIndex >= level.flow.length;
+      return {
+        ...state,
+        phase: 'animating',
+        currentFlowIndex: 0,
+        currentAnimWaypoint: 0,
+        animatingBall: {
+          ballId: firstStep.ballId,
+          path: firstStep.animationPath,
+          waypointIndex: 0,
+          from: firstStep.animationPath[0],
+          to: firstStep.animationPath.length > 1 ? firstStep.animationPath[1] : firstStep.animationPath[0],
+        },
+        eventLoopActive: false,
+      };
+    }
 
-      // Remove ball from placed, add to executed, add output
-      const newPlaced = { ...state.placedBalls };
-      const comp = expectedStep.component;
-      if (newPlaced[comp]) {
-        newPlaced[comp] = newPlaced[comp].filter(id => id !== expectedStep.ballId);
+    case 'ADVANCE_WAYPOINT': {
+      const currentStep = level.flow[state.currentFlowIndex];
+      if (!currentStep) return state;
+
+      const path = currentStep.animationPath;
+      const nextWaypoint = state.currentAnimWaypoint + 1;
+
+      if (nextWaypoint >= path.length) {
+        return state;
       }
+
+      const isQueueToCallstack = (
+        (path[nextWaypoint - 1] === 'microtask' || path[nextWaypoint - 1] === 'macrotask') &&
+        path[nextWaypoint] === 'callstack'
+      );
+
+      return {
+        ...state,
+        currentAnimWaypoint: nextWaypoint,
+        animatingBall: {
+          ballId: currentStep.ballId,
+          path: path,
+          waypointIndex: nextWaypoint,
+          from: path[nextWaypoint - 1],
+          to: path[nextWaypoint],
+        },
+        eventLoopActive: isQueueToCallstack,
+      };
+    }
+
+    case 'FINISH_FLOW_STEP': {
+      const currentStep = level.flow[state.currentFlowIndex];
+      if (!currentStep) return state;
+
+      const newPlaced = { ...state.placedBalls };
+      Object.keys(newPlaced).forEach(key => {
+        newPlaced[key] = newPlaced[key].filter(id => id !== currentStep.ballId);
+      });
 
       const baseScore = 100;
       const penalty = state.wrongMoves * 10;
       const stepScore = Math.max(baseScore - penalty, 10);
 
+      const nextFlowIndex = state.currentFlowIndex + 1;
+      const isLastStep = nextFlowIndex >= level.flow.length;
+
+      if (isLastStep) {
+        return {
+          ...state,
+          currentFlowIndex: nextFlowIndex,
+          outputs: [...state.outputs, currentStep.output],
+          executedBalls: [...state.executedBalls, currentStep.ballId],
+          placedBalls: newPlaced,
+          score: state.score + stepScore,
+          phase: 'complete',
+          showLevelComplete: true,
+          animatingBall: null,
+          eventLoopActive: false,
+          feedback: null,
+        };
+      }
+
+      const nextStep = level.flow[nextFlowIndex];
       return {
         ...state,
-        currentStepIndex: nextStepIndex,
-        outputs: [...state.outputs, expectedStep.output],
-        executedBalls: [...state.executedBalls, expectedStep.ballId],
+        currentFlowIndex: nextFlowIndex,
+        currentAnimWaypoint: 0,
+        outputs: [...state.outputs, currentStep.output],
+        executedBalls: [...state.executedBalls, currentStep.ballId],
         placedBalls: newPlaced,
         score: state.score + stepScore,
-        phase: isLastStep ? 'complete' : 'drag',
-        showLevelComplete: isLastStep,
+        phase: 'animating',
+        animatingBall: {
+          ballId: nextStep.ballId,
+          path: nextStep.animationPath,
+          waypointIndex: 0,
+          from: nextStep.animationPath[0],
+          to: nextStep.animationPath.length > 1 ? nextStep.animationPath[1] : nextStep.animationPath[0],
+        },
+        eventLoopActive: false,
         feedback: null,
       };
     }
@@ -120,7 +211,9 @@ function gameReducer(state, action) {
       return {
         ...state,
         currentLevelIndex: nextIndex,
-        currentStepIndex: 0,
+        currentPlacementIndex: 0,
+        currentFlowIndex: 0,
+        currentAnimWaypoint: 0,
         phase: 'drag',
         outputs: [],
         placedBalls: {},
@@ -130,6 +223,9 @@ function gameReducer(state, action) {
         showLevelComplete: false,
         wrongMoves: 0,
         totalMoves: 0,
+        animatingBall: null,
+        eventLoopActive: false,
+        allPlaced: false,
       };
     }
 
@@ -137,7 +233,9 @@ function gameReducer(state, action) {
       const lvl = LEVELS[state.currentLevelIndex];
       return {
         ...state,
-        currentStepIndex: 0,
+        currentPlacementIndex: 0,
+        currentFlowIndex: 0,
+        currentAnimWaypoint: 0,
         phase: 'drag',
         outputs: [],
         placedBalls: {},
@@ -147,6 +245,9 @@ function gameReducer(state, action) {
         showLevelComplete: false,
         wrongMoves: 0,
         totalMoves: 0,
+        animatingBall: null,
+        eventLoopActive: false,
+        allPlaced: false,
       };
     }
 
@@ -155,7 +256,6 @@ function gameReducer(state, action) {
   }
 }
 
-// Create Context
 const GameContext = createContext(null);
 
 export function GameProvider({ children }) {
@@ -164,7 +264,18 @@ export function GameProvider({ children }) {
     remainingBalls: LEVELS[0].balls.map(b => b.id),
   });
 
-  // Memoized dispatch wrappers
+  const componentRefs = useRef({});
+
+  const registerComponentRef = useCallback((id, element) => {
+    componentRefs.current[id] = element;
+  }, []);
+
+  const getComponentRect = useCallback((id) => {
+    const el = componentRefs.current[id];
+    if (el) return el.getBoundingClientRect();
+    return null;
+  }, []);
+
   const initLevel = useCallback((levelIndex) => {
     dispatch({ type: 'INIT_LEVEL', levelIndex });
   }, []);
@@ -173,8 +284,16 @@ export function GameProvider({ children }) {
     dispatch({ type: 'PLACE_BALL', ballId, componentId });
   }, []);
 
-  const executeStep = useCallback(() => {
-    dispatch({ type: 'EXECUTE_STEP' });
+  const startExecution = useCallback(() => {
+    dispatch({ type: 'START_EXECUTION' });
+  }, []);
+
+  const advanceWaypoint = useCallback(() => {
+    dispatch({ type: 'ADVANCE_WAYPOINT' });
+  }, []);
+
+  const finishFlowStep = useCallback(() => {
+    dispatch({ type: 'FINISH_FLOW_STEP' });
   }, []);
 
   const clearFeedback = useCallback(() => {
@@ -196,7 +315,20 @@ export function GameProvider({ children }) {
   const value = {
     ...state,
     level: LEVELS[state.currentLevelIndex],
-    actions: { initLevel, placeBall, executeStep, clearFeedback, nextLevel, resetLevel, setPhase },
+    componentRefs,
+    registerComponentRef,
+    getComponentRect,
+    actions: {
+      initLevel,
+      placeBall,
+      startExecution,
+      advanceWaypoint,
+      finishFlowStep,
+      clearFeedback,
+      nextLevel,
+      resetLevel,
+      setPhase,
+    },
   };
 
   return <GameContext.Provider value={value}>{children}</GameContext.Provider>;

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,5 @@
 @import "tailwindcss";
 
-/* ===== CUSTOM THEME ===== */
 :root {
   --color-bg: #0f0a2e;
   --color-bg-card: rgba(30, 20, 70, 0.85);
@@ -30,19 +29,16 @@ html, body, #root {
   color: var(--color-text);
 }
 
-/* ===== SCROLLBAR ===== */
 ::-webkit-scrollbar { width: 6px; }
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb { background: rgba(167, 139, 250, 0.3); border-radius: 3px; }
 
-/* ===== GLOW EFFECTS ===== */
 .glow-green { filter: drop-shadow(0 0 12px rgba(74, 222, 128, 0.6)); }
 .glow-purple { filter: drop-shadow(0 0 12px rgba(192, 132, 252, 0.6)); }
 .glow-blue { filter: drop-shadow(0 0 12px rgba(96, 165, 250, 0.6)); }
 .glow-yellow { filter: drop-shadow(0 0 12px rgba(251, 191, 36, 0.6)); }
 .glow-pink { filter: drop-shadow(0 0 12px rgba(244, 114, 182, 0.6)); }
 
-/* ===== GLASS CARD ===== */
 .glass-card {
   background: var(--color-bg-card);
   backdrop-filter: blur(16px);
@@ -50,7 +46,6 @@ html, body, #root {
   border-radius: 20px;
 }
 
-/* ===== ENGINE COMPONENT BOX ===== */
 .engine-box {
   border-radius: 20px;
   padding: 12px;
@@ -63,8 +58,15 @@ html, body, #root {
   transform: scale(1.03);
   box-shadow: 0 0 30px rgba(251, 191, 36, 0.4);
 }
+.engine-box.receiving {
+  animation: pulse-border 0.8s ease-in-out infinite;
+}
 
-/* ===== BALL STYLES ===== */
+@keyframes pulse-border {
+  0%, 100% { filter: brightness(1); }
+  50% { filter: brightness(1.3); }
+}
+
 .task-ball {
   width: 56px;
   height: 56px;
@@ -99,7 +101,6 @@ html, body, #root {
   color: #1e3a5f;
 }
 
-/* ===== CODE PANEL ===== */
 .code-line {
   font-family: var(--font-code);
   font-size: 13px;
@@ -116,7 +117,6 @@ html, body, #root {
   border-left-color: var(--color-accent);
 }
 
-/* ===== OUTPUT TERMINAL ===== */
 .terminal {
   font-family: var(--font-code);
   font-size: 13px;
@@ -137,7 +137,6 @@ html, body, #root {
   border-radius: 50%;
 }
 
-/* ===== HINT BUBBLE ===== */
 .hint-bubble {
   background: linear-gradient(135deg, rgba(251, 191, 36, 0.15), rgba(244, 114, 182, 0.15));
   border: 1px solid rgba(251, 191, 36, 0.3);
@@ -158,7 +157,6 @@ html, body, #root {
   transform: rotate(45deg);
 }
 
-/* ===== BUTTON ===== */
 .btn-execute {
   background: linear-gradient(135deg, #fbbf24, #f59e0b);
   color: #451a03;
@@ -201,8 +199,12 @@ html, body, #root {
   background: rgba(167, 139, 250, 0.25);
   transform: translateY(-1px);
 }
+.btn-secondary:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  transform: none;
+}
 
-/* ===== LEVEL COMPLETE OVERLAY ===== */
 .overlay {
   position: fixed;
   inset: 0;
@@ -214,7 +216,6 @@ html, body, #root {
   z-index: 100;
 }
 
-/* ===== SCORE BADGE ===== */
 .score-badge {
   background: linear-gradient(135deg, #fbbf24, #f97316);
   color: #451a03;
@@ -225,7 +226,6 @@ html, body, #root {
   box-shadow: 0 2px 12px rgba(251, 191, 36, 0.3);
 }
 
-/* ===== LEVEL TABS ===== */
 .level-tab {
   padding: 6px 16px;
   border-radius: 12px;
@@ -241,6 +241,117 @@ html, body, #root {
 }
 .level-tab:hover:not(.active) {
   background: rgba(167, 139, 250, 0.1);
+}
+.level-tab:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ===== EVENT LOOP WIDGET ===== */
+.event-loop-widget {
+  width: 140px;
+  height: 140px;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.event-loop-center {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: linear-gradient(145deg, rgba(30, 20, 70, 0.95), rgba(50, 30, 90, 0.95));
+  border: 2.5px solid rgba(251, 191, 36, 0.5);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  z-index: 2;
+}
+
+.event-loop-label {
+  font-size: 8px;
+  font-weight: 900;
+  letter-spacing: 1.5px;
+  color: #fbbf24;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.event-loop-icon {
+  font-size: 16px;
+  color: #fbbf24;
+  line-height: 1;
+  margin-top: 1px;
+}
+
+.event-loop-pulse-ring {
+  position: absolute;
+  inset: -5px;
+  border-radius: 50%;
+  border: 2px solid rgba(251, 191, 36, 0.4);
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* ===== FLOW ANIMATION ===== */
+.flow-animation-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  pointer-events: none;
+}
+
+.flow-trail-svg {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.flow-ball {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 51;
+}
+
+.flow-ball-shine {
+  position: absolute;
+  top: 6px;
+  left: 8px;
+  width: 15px;
+  height: 10px;
+  background: rgba(255, 255, 255, 0.4);
+  border-radius: 50%;
+  transform: rotate(-30deg);
+  pointer-events: none;
+}
+
+.flow-ball-label {
+  position: relative;
+  z-index: 2;
+  font-weight: 800;
+  font-size: 9px;
+  color: white;
+  text-shadow: 0 1px 3px rgba(0,0,0,0.5);
+}
+
+.flow-waypoint-label {
+  position: absolute;
+  transform: translateX(-50%);
+  font-size: 10px;
+  font-weight: 700;
+  color: rgba(251, 191, 36, 0.8);
+  white-space: nowrap;
+  text-shadow: 0 0 8px rgba(251, 191, 36, 0.4);
+  pointer-events: none;
+  z-index: 52;
 }
 
 /* ===== ANIMATIONS ===== */


### PR DESCRIPTION
- Implemented ordering enforcement in  and . Players must now place task balls in the sequence they appear in the source code (top-to-bottom) rather than execution order.
- Added a new  component to replace the emoji spinner, featuring a prominent, cartoonish SVG animation with concentric rotating arrows that accelerate during task transfers.
- Created  overlay to visually trace the execution path (e.g., Call Stack → Web API → Microtask Queue → Call Stack) with custom SVG trailing paths and glowing waypoint markers.
- Refactored game phases in  (, , , complete -F _longopt mv complete -F _longopt head
complete -F _service /etc/init.d/rsync
complete -F _longopt uniq
complete -F _command else
complete -F _longopt mkfifo
complete -F _longopt tee
complete -F _service /etc/init.d/x11-common
complete -F _longopt grep
complete -F _longopt objdump
complete -F _longopt sha1sum
complete -F _longopt cut
complete -F _service /etc/init.d/plymouth
complete -F _command nohup
complete -a unalias
complete -u groups
complete -F _longopt texindex
complete -F _known_hosts telnet
complete -F _command vsound
complete -F _service /etc/init.d/cups
complete -c which
complete -F _longopt m4
complete -F _longopt cp
complete -F _longopt base64
complete -o default -F _sdk sdk
complete -F _service /etc/init.d/mariadb
complete -F _longopt strip
complete -o bashdefault -o default -o nospace -F __git_wrap__gitk_main gitk complete -F _service /etc/init.d/sudo
complete -v readonly
complete -o nospace -F _cd cd
complete -F _known_hosts showmount
complete -F _longopt tac
complete -F _known_hosts fping
complete -F _longopt env
complete -F _service /etc/init.d/lm-sensors
complete -c type
complete -F _known_hosts ssh-installkeys
complete -F _longopt expand
complete -o bashdefault -o default -o nospace -F __git_wrap__git_main git complete -F _longopt ln
complete -F _command aoss
complete -F _service /etc/init.d/alsa-utils
complete -F _service /etc/init.d/ufw
complete -F _longopt ld
complete -F _service /etc/init.d/apparmor
complete -F _longopt enscript
complete -F _command xargs
complete -j -P '"%' -S '"' jobs
complete -F _service service
complete -F _longopt tail
complete -F _longopt unexpand
complete -F _longopt netstat
complete -F _longopt ls
complete -o nospace -F _cd pushd
complete -v unset
complete -F _longopt csplit
complete -F _known_hosts rsh
complete -F _command exec
complete -F _service /etc/init.d/cgroupfs-mount
complete -F _longopt sum
complete -F _longopt nm
complete -F _longopt nl
complete -F _user_at_host ytalk
complete -u sux
complete -F _service /etc/init.d/networking
complete -F _longopt paste
complete -F _longopt dir
complete -F _longopt a2ps
complete -F _root_command really
complete -F _service /etc/init.d/hwclock.sh
complete -F _service /etc/init.d/anacron
complete -F _known_hosts dig
complete -F _user_at_host talk
complete -F _service /etc/init.d/keyboard-setup.sh complete -F _longopt df
complete -F _command eval
complete -F _longopt chroot
complete -F _service /etc/init.d/nvidia-persistenced complete -F _command do
complete -F _service /etc/init.d/dbus
complete -F _service /etc/init.d/saned
complete -F _longopt du
complete -F _longopt wc
complete -o default -F __nvm nvm
complete -A shopt shopt
complete -F _known_hosts ftp
complete -F _longopt uname
complete -F _known_hosts rlogin
complete -F _longopt sha384sum
complete -F _longopt rm
complete -F _root_command gksudo
complete -F _command nice
complete -F _longopt tr
complete -F _longopt sha256sum
complete -F _root_command gksu
complete -F _service /etc/init.d/cups-browsed
complete -F _longopt ptx
complete -F _known_hosts traceroute
complete -j -P '"%' -S '"' fg
complete -F _longopt who
complete -F _longopt less
complete -F _longopt mknod
complete -F _command padsp
complete -F _service /etc/init.d/console-setup.sh
complete -F _longopt bison
complete -F _longopt od
complete -F _service /etc/init.d/nginx
complete -F _service /etc/init.d/kmod
complete -F _service /etc/init.d/gdm3
complete -F _completion_loader -D
complete -F _longopt split
complete -F _longopt fold
complete -F _known_hosts mtr
complete -F _user_at_host finger
complete -F _root_command kdesudo
complete -u w
complete -F _longopt irb
complete -F _command tsocks
complete -F _longopt diff
complete -F _longopt shar
complete -F _longopt vdir
complete -F _service /etc/init.d/plymouth-log
complete -j -P '"%' -S '"' disown
complete -F _longopt bash
complete -F _service /etc/init.d/procps
complete -F _longopt md5sum
complete -A stopped -P '"%' -S '"' bg
complete -F _longopt objcopy
complete -F _longopt bc
complete -b builtin
complete -F _longopt shasum
complete -F _command ltrace
complete -F _known_hosts traceroute6
complete -F _longopt date
complete -F _longopt cat
complete -F _longopt readelf
complete -F _longopt awk
complete -F _longopt sha512sum
complete -F _longopt seq
complete -F _longopt mkdir
complete -F _longopt sha224sum
complete -F _service /etc/init.d/speech-dispatcher complete -A helptopic help
complete -F _minimal ''
complete -A setopt set
complete -F _longopt sort
complete -F _longopt pr
complete -F _longopt colordiff
complete -F _longopt fmt
complete -F _service /etc/init.d/bluetooth
complete -F _longopt sed
complete -F _longopt gperf
complete -F _command time
complete -F _service /etc/init.d/udev
complete -F _root_command fakeroot
complete -u slay
complete -F _longopt grub
complete -F _service /etc/init.d/cron
complete -F _longopt rmdir
complete -F _longopt units
complete -F _longopt touch
complete -F _longopt ldd
complete -F _command then
complete -F _command command
complete -F _known_hosts fping6
complete -F _service /etc/init.d/binfmt-support
complete -F _service /etc/init.d/mono-xsp4) enabling a multi-step animation sequence that triggers only after all balls are placed.
- Updated , , and  to interact with the new component ref registry and to disable drag interactions during the animation state.
- Styled new components in  to match the existing neon-cartoon aesthetic.